### PR TITLE
Enable Travis CI for a Rug Archive

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -15,3 +15,24 @@ generator:
     - "group_id": "mygroup"
     - "version": "0.1.0"
 
+---
+kind: "operation"
+client: "atomist-bot"
+executor:
+  name: "EnableTravisForRugArchive"
+  group: "atomist-rugs"
+  artifact: "travis-editors"
+  version: "0.12.0"
+  origin:
+    repo: "https://github.com/atomist-rugs/travis-editors.git"
+    branch: "678d3e9ccbf3b22079e7551530d9142d3bfdd364"
+    sha: "678d3e9"
+  parameters:
+    - "github_token": "d**************************************0"
+    - "maven_user": "t***************y"
+    - "maven_token": "z**************7"
+    - "owner": "atomisthqa"
+    - "repo": "rug-test-10"
+    - "org": ".org"
+    - "maven_base_url": "https://atomist.jfrog.io/atomist"
+

--- a/.atomist/build/cli-build.yml
+++ b/.atomist/build/cli-build.yml
@@ -1,0 +1,16 @@
+# Set up the path to the local repository
+local-repository:
+  path: "${HOME}/.atomist/repository"
+
+# Set up remote repositories to query for Rug archives. Additionally one of the
+# repositories can also be enabled for publication (publish: true).
+remote-repositories:
+  maven-central:
+    publish: false
+    url: "http://repo.maven.apache.org/maven2/"
+  rug-types:
+    publish: false
+    url: "https://atomist.jfrog.io/atomist/libs-release"
+  rugs-release:
+    publish: false
+    url: "https://atomist.jfrog.io/atomist/rugs-release"

--- a/.atomist/build/cli-dev.yml
+++ b/.atomist/build/cli-dev.yml
@@ -1,0 +1,19 @@
+# Set up the path to the local repository
+local-repository:
+  path: "${HOME}/.atomist/repository"
+
+# Set up remote repositories to query for Rug archives. Additionally one of the
+# repositories can also be enabled for publication (publish: true).
+remote-repositories:
+  maven-central:
+    publish: false
+    url: "http://repo.maven.apache.org/maven2/"
+  rug-types:
+    publish: false
+    url: "https://atomist.jfrog.io/atomist/libs-release"
+  rugs-dev:
+    publish: true
+    url: "${MAVEN_BASE_URL}/rugs-dev"
+    authentication:
+      username: "${MAVEN_USER}"
+      password: "${MAVEN_TOKEN}"

--- a/.atomist/build/cli-release.yml
+++ b/.atomist/build/cli-release.yml
@@ -1,0 +1,19 @@
+# Set up the path to the local repository
+local-repository:
+  path: "${HOME}/.atomist/repository"
+
+# Set up remote repositories to query for Rug archives. Additionally one of the
+# repositories can also be enabled for publication (publish: true).
+remote-repositories:
+  maven-central:
+    publish: false
+    url: "http://repo.maven.apache.org/maven2/"
+  rug-types:
+    publish: false
+    url: "https://atomist.jfrog.io/atomist/libs-release"
+  rugs-release:
+    publish: true
+    url: "${MAVEN_BASE_URL}/rugs-release"
+    authentication:
+      username: "${MAVEN_USER}"
+      password: "${MAVEN_TOKEN}"

--- a/.atomist/build/travis-build.bash
+++ b/.atomist/build/travis-build.bash
@@ -1,0 +1,162 @@
+#!/bin/bash
+# test and publish rug archive
+
+set -o pipefail
+
+declare Pkg=travis-build
+declare Version=0.3.0
+
+function msg() {
+    echo "$Pkg: $*"
+}
+
+function err() {
+    msg "$*" 1>&2
+}
+
+# usage: main "$@"
+function main () {
+    local formula_url=https://raw.githubusercontent.com/atomist/homebrew-tap/master/Formula/rug-cli.rb
+    local formula
+    formula=$(curl -s -f "$formula_url")
+    if [[ $? -ne 0 || ! $formula ]]; then
+        err "failed to download homebrew formula $formula_url: $formula"
+        return 1
+    fi
+
+    local version
+    version=$(echo "$formula" | sed -n '/^ *url /s,.*/\([0-9]*\.[0-9]*\.[0-9]*\)/.*,\1,p')
+    if [[ $? -ne 0 || ! $version ]]; then
+        err "failed to parse brew formula for version: $version"
+        err "$formula"
+        return 1
+    fi
+    msg "rug CLI version: $version"
+
+    local rug=$HOME/.atomist/rug-cli-$version/bin/rug
+    if [[ ! -x $rug ]]; then
+        msg "downloading rug CLI"
+        if ! mkdir -p "$HOME/.atomist"; then
+            err "failed to make ~/.atomist directory"
+            return 1
+        fi
+
+        local rug_cli_url=https://github.com/atomist/rug-cli/releases/download/$version/rug-cli-$version-bin.tar.gz
+        local rug_cli_tgz=$HOME/.atomist/rug-cli-$version.tar.gz
+        if ! curl -s -f -L -o "$rug_cli_tgz" "$rug_cli_url"; then
+            err "failed to download rug CLI from $rug_cli_url"
+            return 1
+        fi
+
+        if ! tar -xzf "$rug_cli_tgz" -C "$HOME/.atomist"; then
+            err "failed to extract rug CLI archive"
+            return 1
+        fi
+    fi
+    rug="$rug -qurX"
+
+    local build_dir=.atomist/build
+    local cli_user=$HOME/.atomist/cli.yml
+    if ! install --mode=0600 "$build_dir/cli-build.yml" "$cli_user"; then
+        err "failed to install build cli.yml"
+        return 1
+    fi
+    trap "rm -f $cli_user" RETURN
+
+    if [[ -f .atomist/package.json ]]; then
+        msg "running npm install"
+        if ! ( cd .atomist && npm install ); then
+            err "npm install failed"
+            return 1
+        fi
+    fi
+
+    msg "running tests"
+    if ! $rug test; then
+        err "rug test failed"
+        return 1
+    fi
+
+    msg "installing archive"
+    if ! $rug install; then
+        err "rug install failed"
+        return 1
+    fi
+
+    [[ $TRAVIS_PULL_REQUEST == false ]] || return 0
+
+    local archive_version
+    local manifest=.atomist/manifest.yml package=.atomist/package.json
+    if [[ -f $manifest ]]; then
+        archive_version=$(awk -F: '$1 == "version" { print $2 }' "$manifest" | sed 's/[^.0-9]//g')
+    elif [[ -f $package ]]; then
+        archive_version=$(jq --raw-output --exit-status .version "$package")
+    else
+        err "no manifest.yml or package.json in archive"
+        return 1
+    fi
+    if [[ $? -ne 0 || ! $archive_version ]]; then
+        err "failed to extract archive version: $archive_version"
+        return 1
+    fi
+    local project_version cli_yml project_group
+    if [[ $TRAVIS_TAG =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        if [[ $archive_version != $TRAVIS_TAG ]]; then
+            err "archive version ($archive_version) does not match git tag ($TRAVIS_TAG)"
+            return 1
+        fi
+        project_version=$TRAVIS_TAG
+        cli_yml=$build_dir/cli-release.yml
+    else
+        local timestamp
+        timestamp=$(date +%Y%m%d%H%M%S)
+        if [[ $? -ne 0 || ! $timestamp ]]; then
+            err "failed to generate timestamp: $timestamp"
+            return 1
+        fi
+        project_version=$archive_version-$timestamp
+        cli_yml=$build_dir/cli-dev.yml
+    fi
+    project_group=$(echo "$TRAVIS_REPO_SLUG" | sed -n -E 's/(.*)\/.*/\1/p')
+    if [[ $? -ne 0 || ! $project_group ]]; then
+        err "failed to extract archive group: $project_group"
+        return 1
+    fi
+
+    msg "branch: $TRAVIS_BRANCH"
+    msg "archive version: $project_version"
+    msg "archive group: $project_group"
+
+    if [[ $TRAVIS_BRANCH == master || $TRAVIS_TAG =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        if ! install --mode=0600 "$cli_yml" "$cli_user"; then
+            err "failed to install $cli_yml"
+            return 1
+        fi
+
+        msg "publishing archive"
+        if ! $rug publish --archive-version "$project_version" --archive-group "$project_group"; then
+            err "failed to publish archive $project_version"
+            return 1
+        fi
+        if ! git config --global user.email "travis-ci@atomist.com"; then
+            err "failed to set git user email"
+            return 1
+        fi
+        if ! git config --global user.name "Travis CI"; then
+            err "failed to set git user name"
+            return 1
+        fi
+        local git_tag=$project_version+travis$TRAVIS_BUILD_NUMBER
+        if ! git tag "$git_tag" -m "Generated tag from TravisCI build $TRAVIS_BUILD_NUMBER"; then
+            err "failed to create git tag: $git_tag"
+            return 1
+        fi
+        if ! git push --quiet --tags "https://$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG" > /dev/null 2>&1; then
+            err "failed to push git tags"
+            return 1
+        fi
+    fi
+}
+
+main "$@" || exit 1
+exit 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+dist: trusty
+sudo: false
+language: java
+jdk:
+- oraclejdk8
+branches:
+  except:
+  - /\+travis\d+$/
+env:
+  global:
+  - MAVEN_BASE_URL=https://atomist.jfrog.io/atomist
+  - secure: HVwE+PIucMnh8Y2abDDuoSp44Z4XZsqOuUM6eT94ooDJLGRn6JTzOXnMpEbyPlqVSVv/rczjqzn/5O/MU47vJ60bC15LavB+aDEINRgWkap+QGSB0JL1891CPU2vBYIHsAaq6FAF7gxpG64EskJrL4DKkh6EZcyNdGzeUa/FDQqH6rzho032u+HuJHIlRXKs/8h2EBi2072mVqnWyCld0D8pgijCgfSIn8vIi5tJP69jvhS84zY/9KYh1T1lENR9iT9RoE8gwbLcFgwt1Zz1xhkyD3J25V7uLx0GEbEn6E91zdPme0isdcvhaEbGv2D31hjfItJZj1ZHbGJ5uNiauT7SCFkAtMFkJeOlowigXnPtE+afSHmigIjqPQQ4sgHt+d0qw1mazLkpu9ARxuo6Hcq2G9wBmQnnrqowSOwSHNuxPi+wbl3JhnUgqh7gvihU9F5SBIs2/mxghdNQ6GHhtNGNiL2oovK8JySe37mA8wuJl4ZnSOVDiZCqIzz7BHm1Tb98IHovUxgxu/xNLt2yS2l0BADi3glBWyDADwHm3/y6ONkROweJ/4vq0qHmpuI/ZdC1uMI9WUyBHWT7BN3Mx1hWpmbbBWQmlD38KgBtCQlxXNq2apkHAIcbQk8Bh0cMTZ1NJQN/saycfTXNRYmhfATiIPAJzoZ+9pZ2zoll5l0=
+  - secure: WOZJ/7xya7c4FiBP27QFNfgYK291430hyXDEWXkyr7iQDTHXs4e6u7Ek/bpi9mwerfPWh7LotGIDmkTl3ntuWX5qKmwr7zzxGsNJImNFOmp2S3dhxs2p3QhTuk9wU0CsRzLAMdtBanpNVpcUJbnVAmDUK65UUh14a4/z3ZP2S0GWcurbxik5ZQlyoEBXD+Wn7E4Wu/agQRs+JFnCXieMFBvNF7UhFN3V2cJuVLWqhyQERwocWBEQO/IXXt9M78vzhrdLFgGYAOydyZEmcv4Mw26+6aNxRXs0R6Pksu6mhPVC1AGXb2EWFH5bezegDlUGuNoz201lHL10syQfjbEIMdlQo78Pv6D+Od/pf+lSjnGDaeSWPX4oojcTmTHS+DjuFHJugL4snlPz25y8C+hBGUy/4ztz1uTmdElogIMOLu6Rx61D4prJXyhXf/bVz2PRaTvVFI81I+GQftXttPRPeKvwf2ckV0kpiPBEhvdE/lIGBkgwsNm+u09Gb5XkSc9ktar+EaBW6IZ2pnXSNpG4dAYa1n5snFLfvhDdNSVq/+vjJmqjSMQi8YFcA7MAi2MOZAaGchtAY2B3z8GoeTvr7nbwwtjS/wIy5mRqyaIyTUFn4rXL59icgls5oRYUMu5fUxVB7tyo4mvESQLhViG5nlK0/g+gmOUfPCVkR2JhbiI=
+  - secure: hjCvvkEx6jrNNSiOSKX5aB+IJpwocAIdhZBEKYDXTDz/q6K3ICw05dehFF1DV/SIlE+xg8TQMQs8c8AzcY4htMPgyVnvi72aZXcXX32EF6mWNOCp9/FEm2nXm8DI1kxCcypgQVzZNH3/d5+aqgZwNWjEN85xF5KhLdJnboslCdPaNRrXADTNp+ZxjMs7ppFBTTl7V4UV22/638HmEUiLD/PYV72LHbzNzG1aqNlrILsUa7kJnP+giniuHFGJP0Hi6OgRaPVu1bRoa06BVgEhkeAK8ijb08bWRdiz5ysxdwLbkNkEsUD00Pt4ik4A6KZyKdflTNTUf6WcSz161tqgnqnZqJDpTrdWim3hSMkgfAwBP9eww/VzZMS3JdiIXWTEXuEZHkcsR3EjUmmbazhxoi5qe721GrO/ZXqQUyv5fZf9AlWzynLYJPjspYxHt3YW9JNMaQzf9bE8t3p7sS8sNIC1a+1SJeqeJowEFy+LdZ2dUlABuX3Gk5HUzq2cC/Vb5lvRfsMbxwaI9oJg2Y4OjGPIO1U6AaeGYuwMnPSJwm67nl1beKvcKy6anXZvD3DzsFerT2WIyLOVg0VekqQwzp7FE8I7udBZIxEYolvhskemoX4Vyef/esBKTE5JSmnFxi14Oe/52Uzv2w4rRzfB7RzfTA2A12697at+BHSfn1c=
+install:
+- nvm install 6.9.2
+script: bash .atomist/build/travis-build.bash
+notifications:
+  email: false
+  webhooks:
+    urls:
+    - https://webhook.atomist.com/travis
+    on_success: always
+    on_failure: always
+    on_start: always
+cache:
+  directories:
+  - $HOME/.atomist


### PR DESCRIPTION
Created by Atomist Executor `EnableTravisForRugArchive`
```
---
kind: "operation"
client: "atomist-bot"
executor:
  name: "EnableTravisForRugArchive"
  group: "atomist-rugs"
  artifact: "travis-editors"
  version: "0.12.0"
  origin:
    repo: "https://github.com/atomist-rugs/travis-editors.git"
    branch: "678d3e9ccbf3b22079e7551530d9142d3bfdd364"
    sha: "678d3e9"
  parameters:
    - "github_token": "d**************************************0"
    - "maven_user": "t***************y"
    - "maven_token": "z**************7"
    - "owner": "atomisthqa"
    - "repo": "rug-test-10"
    - "org": ".org"
    - "maven_base_url": "https://atomist.jfrog.io/atomist"

```