### PR TITLE
Enable Travis CI for a Rug Archive

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -15,3 +15,24 @@ generator:
     - "group_id": "mygroup"
     - "version": "0.1.0"
 
+---
+kind: "operation"
+client: "atomist-bot"
+executor:
+  name: "EnableTravisForRugArchive"
+  group: "atomist-rugs"
+  artifact: "travis-editors"
+  version: "0.12.0"
+  origin:
+    repo: "https://github.com/atomist-rugs/travis-editors.git"
+    branch: "678d3e9ccbf3b22079e7551530d9142d3bfdd364"
+    sha: "678d3e9"
+  parameters:
+    - "github_token": "9**************************************6"
+    - "maven_user": "t***************y"
+    - "maven_token": "z**************7"
+    - "owner": "atomisthqa"
+    - "repo": "rug-test-10"
+    - "org": ".org"
+    - "maven_base_url": "https://atomist.jfrog.io/atomist"
+

--- a/.atomist/build/cli-build.yml
+++ b/.atomist/build/cli-build.yml
@@ -1,0 +1,16 @@
+# Set up the path to the local repository
+local-repository:
+  path: "${HOME}/.atomist/repository"
+
+# Set up remote repositories to query for Rug archives. Additionally one of the
+# repositories can also be enabled for publication (publish: true).
+remote-repositories:
+  maven-central:
+    publish: false
+    url: "http://repo.maven.apache.org/maven2/"
+  rug-types:
+    publish: false
+    url: "https://atomist.jfrog.io/atomist/libs-release"
+  rugs-release:
+    publish: false
+    url: "https://atomist.jfrog.io/atomist/rugs-release"

--- a/.atomist/build/cli-dev.yml
+++ b/.atomist/build/cli-dev.yml
@@ -1,0 +1,19 @@
+# Set up the path to the local repository
+local-repository:
+  path: "${HOME}/.atomist/repository"
+
+# Set up remote repositories to query for Rug archives. Additionally one of the
+# repositories can also be enabled for publication (publish: true).
+remote-repositories:
+  maven-central:
+    publish: false
+    url: "http://repo.maven.apache.org/maven2/"
+  rug-types:
+    publish: false
+    url: "https://atomist.jfrog.io/atomist/libs-release"
+  rugs-dev:
+    publish: true
+    url: "${MAVEN_BASE_URL}/rugs-dev"
+    authentication:
+      username: "${MAVEN_USER}"
+      password: "${MAVEN_TOKEN}"

--- a/.atomist/build/cli-release.yml
+++ b/.atomist/build/cli-release.yml
@@ -1,0 +1,19 @@
+# Set up the path to the local repository
+local-repository:
+  path: "${HOME}/.atomist/repository"
+
+# Set up remote repositories to query for Rug archives. Additionally one of the
+# repositories can also be enabled for publication (publish: true).
+remote-repositories:
+  maven-central:
+    publish: false
+    url: "http://repo.maven.apache.org/maven2/"
+  rug-types:
+    publish: false
+    url: "https://atomist.jfrog.io/atomist/libs-release"
+  rugs-release:
+    publish: true
+    url: "${MAVEN_BASE_URL}/rugs-release"
+    authentication:
+      username: "${MAVEN_USER}"
+      password: "${MAVEN_TOKEN}"

--- a/.atomist/build/travis-build.bash
+++ b/.atomist/build/travis-build.bash
@@ -1,0 +1,162 @@
+#!/bin/bash
+# test and publish rug archive
+
+set -o pipefail
+
+declare Pkg=travis-build
+declare Version=0.3.0
+
+function msg() {
+    echo "$Pkg: $*"
+}
+
+function err() {
+    msg "$*" 1>&2
+}
+
+# usage: main "$@"
+function main () {
+    local formula_url=https://raw.githubusercontent.com/atomist/homebrew-tap/master/Formula/rug-cli.rb
+    local formula
+    formula=$(curl -s -f "$formula_url")
+    if [[ $? -ne 0 || ! $formula ]]; then
+        err "failed to download homebrew formula $formula_url: $formula"
+        return 1
+    fi
+
+    local version
+    version=$(echo "$formula" | sed -n '/^ *url /s,.*/\([0-9]*\.[0-9]*\.[0-9]*\)/.*,\1,p')
+    if [[ $? -ne 0 || ! $version ]]; then
+        err "failed to parse brew formula for version: $version"
+        err "$formula"
+        return 1
+    fi
+    msg "rug CLI version: $version"
+
+    local rug=$HOME/.atomist/rug-cli-$version/bin/rug
+    if [[ ! -x $rug ]]; then
+        msg "downloading rug CLI"
+        if ! mkdir -p "$HOME/.atomist"; then
+            err "failed to make ~/.atomist directory"
+            return 1
+        fi
+
+        local rug_cli_url=https://github.com/atomist/rug-cli/releases/download/$version/rug-cli-$version-bin.tar.gz
+        local rug_cli_tgz=$HOME/.atomist/rug-cli-$version.tar.gz
+        if ! curl -s -f -L -o "$rug_cli_tgz" "$rug_cli_url"; then
+            err "failed to download rug CLI from $rug_cli_url"
+            return 1
+        fi
+
+        if ! tar -xzf "$rug_cli_tgz" -C "$HOME/.atomist"; then
+            err "failed to extract rug CLI archive"
+            return 1
+        fi
+    fi
+    rug="$rug -qurX"
+
+    local build_dir=.atomist/build
+    local cli_user=$HOME/.atomist/cli.yml
+    if ! install --mode=0600 "$build_dir/cli-build.yml" "$cli_user"; then
+        err "failed to install build cli.yml"
+        return 1
+    fi
+    trap "rm -f $cli_user" RETURN
+
+    if [[ -f .atomist/package.json ]]; then
+        msg "running npm install"
+        if ! ( cd .atomist && npm install ); then
+            err "npm install failed"
+            return 1
+        fi
+    fi
+
+    msg "running tests"
+    if ! $rug test; then
+        err "rug test failed"
+        return 1
+    fi
+
+    msg "installing archive"
+    if ! $rug install; then
+        err "rug install failed"
+        return 1
+    fi
+
+    [[ $TRAVIS_PULL_REQUEST == false ]] || return 0
+
+    local archive_version
+    local manifest=.atomist/manifest.yml package=.atomist/package.json
+    if [[ -f $manifest ]]; then
+        archive_version=$(awk -F: '$1 == "version" { print $2 }' "$manifest" | sed 's/[^.0-9]//g')
+    elif [[ -f $package ]]; then
+        archive_version=$(jq --raw-output --exit-status .version "$package")
+    else
+        err "no manifest.yml or package.json in archive"
+        return 1
+    fi
+    if [[ $? -ne 0 || ! $archive_version ]]; then
+        err "failed to extract archive version: $archive_version"
+        return 1
+    fi
+    local project_version cli_yml project_group
+    if [[ $TRAVIS_TAG =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        if [[ $archive_version != $TRAVIS_TAG ]]; then
+            err "archive version ($archive_version) does not match git tag ($TRAVIS_TAG)"
+            return 1
+        fi
+        project_version=$TRAVIS_TAG
+        cli_yml=$build_dir/cli-release.yml
+    else
+        local timestamp
+        timestamp=$(date +%Y%m%d%H%M%S)
+        if [[ $? -ne 0 || ! $timestamp ]]; then
+            err "failed to generate timestamp: $timestamp"
+            return 1
+        fi
+        project_version=$archive_version-$timestamp
+        cli_yml=$build_dir/cli-dev.yml
+    fi
+    project_group=$(echo "$TRAVIS_REPO_SLUG" | sed -n -E 's/(.*)\/.*/\1/p')
+    if [[ $? -ne 0 || ! $project_group ]]; then
+        err "failed to extract archive group: $project_group"
+        return 1
+    fi
+
+    msg "branch: $TRAVIS_BRANCH"
+    msg "archive version: $project_version"
+    msg "archive group: $project_group"
+
+    if [[ $TRAVIS_BRANCH == master || $TRAVIS_TAG =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        if ! install --mode=0600 "$cli_yml" "$cli_user"; then
+            err "failed to install $cli_yml"
+            return 1
+        fi
+
+        msg "publishing archive"
+        if ! $rug publish --archive-version "$project_version" --archive-group "$project_group"; then
+            err "failed to publish archive $project_version"
+            return 1
+        fi
+        if ! git config --global user.email "travis-ci@atomist.com"; then
+            err "failed to set git user email"
+            return 1
+        fi
+        if ! git config --global user.name "Travis CI"; then
+            err "failed to set git user name"
+            return 1
+        fi
+        local git_tag=$project_version+travis$TRAVIS_BUILD_NUMBER
+        if ! git tag "$git_tag" -m "Generated tag from TravisCI build $TRAVIS_BUILD_NUMBER"; then
+            err "failed to create git tag: $git_tag"
+            return 1
+        fi
+        if ! git push --quiet --tags "https://$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG" > /dev/null 2>&1; then
+            err "failed to push git tags"
+            return 1
+        fi
+    fi
+}
+
+main "$@" || exit 1
+exit 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+dist: trusty
+sudo: false
+language: java
+jdk:
+- oraclejdk8
+branches:
+  except:
+  - /\+travis\d+$/
+env:
+  global:
+  - MAVEN_BASE_URL=https://atomist.jfrog.io/atomist
+  - secure: VOCFMRkqGvWPbau91AuQildl8qKsFziUMelX3X9tyV9rD+UqnhmDl7Q4udAHKRcIEz4N9mCGUmTNSEmArNzcV0nzB1qDz4vSAt14QLU3rONlLFmznO2zElbOlrmdf4Soer/FSkZulT0iC1Vd6DXjUz98R76cD+QT5yGObkd1DcesxQVohwmJUttQVaQUap8y5tvpciYA6V1piq7mTkj3H8hNtp+YghvRDstsPHwnqKMgzpVdA9zgnPHsCYtBDBf/9gdIiSe47QjOWO2orKPM27lXZRQHm9LCp82k3lfw+h6FuFLowldCT2Ymiazk2/clsxk0cW6rvAkiAgEiHGWBJcX6jasT2fURfdGDcLnRYH+EUVGUcDMBZ82NL4lvf4/RyT08M1e+CmWh00mMSxI9q12Hl5fzF03Tvq/ubJ7LF0MyhTx2O48UQKnst6z666wxk3j9NWvyabQjzgryxhMcGrd34T/eBAbfStht/JhPNhKnusUwyJMEb2RQ7yHf7p5qdbvMz2velmLWymOjLtFybXwQQW+zYYrO4aswpYBte63Ebv43uFJr1yls1C63L84nJH+sc8NPRw5jbAXvVbQhpypOgaA5LlisCg1aTjP6cTPteYMLPPqeKQM2QAMjeHTwzPUfKlwT5Sb1UtcoREXZjz8ug/l65FVLcvOJyd4xNIM=
+  - secure: VIVeO3YN2o0ctznlkD8Hjy8u8+LUkyiJKT5kH+O4BMbeAPIOWRfTQvbwepXhgcigWKKRX9MMOq5ihgvcxHvWl8HLIMETYwdI0++0+3tzqt1xZW/iBRPjDl+sqyp9odATE+UlQuYn6KfHyWChOAbwK1nKsVcyLvgslk7+vXeJJPQ3jetrOiS49i5huwSsf2hvWJv+eiea2J98dnw8zG2uLDAIGu65WIWTmZQ/nDhZgZMepRQlmx4j+PR1RG5Cn0oh8ULnqU3bm9Q58TJotfVk2naIX/w9CuIurzRjpt41rRkfeIcrmnMRJdzqvgqet7pn4s2vgsgncIyFQaf2MptiKP/KVjSYkdOqHgK1pqWBqWy9xNj4w9Q8nzzjY4iv61yLJ8+rfSEO/902tKYwZ+vs2qjegXBuy5QN96xA0i7Zc0ygaKRqbwEgY1UnGacLTxvWZCXfw6b8w+k+a3e2TX1dqWOJNLjJRs13EqMoVG2EaevsYUuCqPGIWR7RltPtZA1faRa6UXGKLGYhLC2WIUo1QDQVoZ0kPdlga9zABpl7iFvuPyzefplS7O5Qc5wO9IDXIX07JJAnMVjEEtaRUn0Rx2/PUR6rUAJQWQ6y/FNwQZmzfFkroOfsXkGslV9INTMsteEyil0Z2/nZ2QXNTxhavL1HuyE4jRrNCJrjaRJHa5A=
+  - secure: WaEGtyn3swZplaHcsQ2eUgHeaiBImQXnKPBFqRxDUsUUOr5MqWhSm1bsgaWOXsyb3xjm5AGokxNWpILClET8OYt+VftqpH/Yfq85uAQ4OqeFYFYHf+P5RNYwb0gdbQUpUZB9ZKslNlSQGoE+kudOLepaV1te9x+RZix+DZfKSRC0oGAOIztD1HrIBuO6CVEC0shO3fPlXGZq+hKGBjM8F13f2WkWd4ALCMrbSisrLhPyPM/QKHUk0ONQf85FNJ5jP+9PXIqE5+dWgfAR5GQtPgSifFNnTltdpDB/YzjODHzHyDzrrxxXfuoN9LzAZw5JL8B29YJHr6auFbMS5I8S9WCBdpvMqOU4r4IrCgG9F/Tm+NL3kGj9lAGFZN776/2rjv2iQOkMWnS2jmzaaGc2kp2iF0+3LAAbe44NCko6WZW2rQOdvNqA4OnH9MutyifeQgSqmZx5E/AS6ACs0lOTFbTb0AzT5eZUs3ohyuiSHFioZHbgT1agJMiJKDzx54bWPMnZWum37UZ2R1kfZ9E+dvefmcM/JLJnjtA8zoZZZfrD8mEhdKrgHXQrzJ6coVJ/fWyI2zf5w2GmxHKeLahiXOboiWg0O7bx+3qlPJ4h0air/CRsyi1JLxRcQl6MnUG0/epvZwIxOO08hvRn20RFdUT0jw2lW3FUL/8IV+4ZKWw=
+install:
+- nvm install 6.9.2
+script: bash .atomist/build/travis-build.bash
+notifications:
+  email: false
+  webhooks:
+    urls:
+    - https://webhook.atomist.com/travis
+    on_success: always
+    on_failure: always
+    on_start: always
+cache:
+  directories:
+  - $HOME/.atomist


### PR DESCRIPTION
Created by Atomist Executor `EnableTravisForRugArchive`
```
---
kind: "operation"
client: "atomist-bot"
executor:
  name: "EnableTravisForRugArchive"
  group: "atomist-rugs"
  artifact: "travis-editors"
  version: "0.12.0"
  origin:
    repo: "https://github.com/atomist-rugs/travis-editors.git"
    branch: "678d3e9ccbf3b22079e7551530d9142d3bfdd364"
    sha: "678d3e9"
  parameters:
    - "github_token": "9**************************************6"
    - "maven_user": "t***************y"
    - "maven_token": "z**************7"
    - "owner": "atomisthqa"
    - "repo": "rug-test-10"
    - "org": ".org"
    - "maven_base_url": "https://atomist.jfrog.io/atomist"

```